### PR TITLE
Fix keyguard prompt reason showing with fingerprint reboot enabled

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -577,11 +577,15 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
         return mUserTrustIsManaged.get(userId) && !isTrustDisabled(userId);
     }
 
+    public boolean isFingerprintUnlockAfterRebootAllowed() {
+        return Settings.System.getInt(mContext.getContentResolver(),
+                    Settings.System.FP_UNLOCK_KEYSTORE, 0) == 1;
+    }
+
     public boolean isUnlockingWithFingerprintAllowed() {
-        return (mStrongAuthTracker.isUnlockingWithFingerprintAllowed()
-                && !hasFingerprintUnlockTimedOut(sCurrentUser))
-                || (Settings.System.getInt(mContext.getContentResolver(),
-                   Settings.System.FP_UNLOCK_KEYSTORE, 0) == 1);
+        return isFingerprintUnlockAfterRebootAllowed() ||
+                (mStrongAuthTracker.isUnlockingWithFingerprintAllowed()
+                && !hasFingerprintUnlockTimedOut(sCurrentUser));
     }
 
     public boolean needsSlowUnlockTransition() {

--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -647,13 +647,14 @@ public class KeyguardViewMediator extends SystemUI {
             boolean trust = mTrustManager.isTrustUsuallyManaged(currentUser);
             boolean fingerprint = mUpdateMonitor.isUnlockWithFingerprintPossible(currentUser);
             boolean any = trust || fingerprint;
+            boolean fpunlock = mUpdateMonitor.isFingerprintUnlockAfterRebootAllowed();
             KeyguardUpdateMonitor.StrongAuthTracker strongAuthTracker =
                     mUpdateMonitor.getStrongAuthTracker();
             int strongAuth = strongAuthTracker.getStrongAuthForUser(currentUser);
 
-            if (any && !strongAuthTracker.hasUserAuthenticatedSinceBoot()) {
+            if (any && !strongAuthTracker.hasUserAuthenticatedSinceBoot() && !fpunlock) {
                 return KeyguardSecurityView.PROMPT_REASON_RESTART;
-            } else if (fingerprint && mUpdateMonitor.hasFingerprintUnlockTimedOut(currentUser)) {
+            } else if (fingerprint && !fpunlock && mUpdateMonitor.hasFingerprintUnlockTimedOut(currentUser)) {
                 return KeyguardSecurityView.PROMPT_REASON_TIMEOUT;
             } else if (any && (strongAuth & STRONG_AUTH_REQUIRED_AFTER_DPM_LOCK_NOW) != 0) {
                 return KeyguardSecurityView.PROMPT_REASON_DEVICE_ADMIN;


### PR DESCRIPTION
When this option is enabled, the user should not see any message
about a PIN being required on reboot or timeout.

Also, clean up the method of the original patch by moving the
function to the first part of the return statement, as Java will
evaluate it first and move on if when true since it's an OR gate.

Change-Id: I3d498ecf3a4db2abfeb6c21797829f2b57758736
Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
Signed-off-by: xyyx <xyyx@mail.ru>